### PR TITLE
Add: vr controller sync

### DIFF
--- a/routes/root.js
+++ b/routes/root.js
@@ -266,7 +266,7 @@ router.post('/alterUser', async (request, response, next) => {
             params = [name, email, new_pw, avatar_id, uid];
         }
         else {
-            query = `update t_user set name=?, email=?, avatar_id=?, vr_hand_sync=b'${vrHandSync}' where id=?`;
+            query = `update t_user set name=?, email=?, avatar_id=? where id=?`;
             params = [name, email, avatar_id, uid];
         }
         await conn.query(query, params);

--- a/routes/root.js
+++ b/routes/root.js
@@ -266,7 +266,7 @@ router.post('/alterUser', async (request, response, next) => {
             params = [name, email, new_pw, avatar_id, uid];
         }
         else {
-            query = `update t_user set name=?, email=?, avatar_id=? where id=?`;
+            query = `update t_user set name=?, email=?, avatar_id=?, vr_hand_sync=b'${vrHandSync}' where id=?`;
             params = [name, email, avatar_id, uid];
         }
         await conn.query(query, params);

--- a/session.js
+++ b/session.js
@@ -346,7 +346,7 @@ class SessionManager {
 
 			let wsSession = null;
 			const { name, avatarPath, vrHandSync } = res1[0];
-			const enableSyncVRHand = (vrHandSync == 1);
+			const enableSyncVRHand = (vrHandSync[0] == 1);
 			console.log(`Socket connected : ${name}`);
 
 			socket.on('joinWS', async (wid) => {


### PR DESCRIPTION
```
try {
    conn = await dbPool.getConnection();
    res1 = await conn.query(`select t_user.name as name, model_path as avatarPath, vr_hand_sync as vrHandSync from t_user join t_avatar on t_user.avatar_id = t_avatar.id where t_user.id = ?`, uid);
} catch (err) {
    console.log(err);
    return;
}
if (conn) {
    conn.release();
}

let wsSession = null;
const { name, avatarPath, vrHandSync } = res1[0];
const enableSyncVRHand = (vrHandSync[0] == 1);
```


vr_hand_sync가 bit 형식이기 때문에 res1[0]에서 vrHandSync로 buffer의 형태로 저장된다.
그래서 enableSyncVRHand에서 0인지 1인지 구분할 수 없었고, vrHandSync버퍼의 맨 앞 인덱스를 읽어오는 방법`vrHandSync[0]`으로 1인지 0인지 bit를 구분할 수 있게 수정했다.